### PR TITLE
Fixed trailing slash bug, reviewed the instructions, added an NGINX example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you want to host multiple TiddlyWikis, you can serve the whole subfolder, and
 `/usr/bin/ruby tw5-server.rb folder`
 
 ## Securing your site
-Suggest running this with a local firewall and/or proxy to secure external connections. The following is a working (but unprotected) proxy configuration for NGINX:
+Suggest running this with a local firewall and/or proxy to secure external connections. The following is a working proxy configuration for NGINX with optional password protection:
 
 ```nginx
 upstream tiddlywiki.example.com {
@@ -32,8 +32,16 @@ server {
         client_max_body_size 20M;
 
         location / {
+                #uncomment these lines to enable password protection after you have set up your user and password
+                #as per https://docs.nginx.com/nginx/admin-guide/security-controls/configuring-http-basic-authentication/
+                #
+                #auth_basic "Restricted";
+                #auth_basic_user_file /etc/nginx/htpasswd;
+
                 proxy_pass http://127.0.0.1:8000;
                 proxy_set_header Host $host;
+                proxy_set_header     X-Real-IP       $remote_addr;
+                proxy_set_header     X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TW5 SERVER
 
-Allows editing and saving of [TiddlyWiki](https://tiddlywiki.com) in a browser. Originally from https://gist.github.com/jimfoltz/ee791c1bdd30ce137bc23cce826096da by Jim Foltz.
+A minimal web server in Ruby that allows editing and saving of [TiddlyWiki](https://tiddlywiki.com) in a browser. Based on https://gist.github.com/jimfoltz/ee791c1bdd30ce137bc23cce826096da by [Jim Foltz](https://gist.github.com/jimfoltz).
 
 ## Installing / Getting started
 First, download TiddlyWiki from https://tiddlywiki.com/empty.html and save it in a subfolder of this script but NOT as index.html. You can do this from the command line (e.g. Terminal on Mac) like so:
@@ -61,16 +61,11 @@ server {
 }
 ```
 
-## Modifications to the original script
-* Added a bind address in the server definition:
-  ```server = WEBrick::HTTPServer.new({:Port => 8000, :DocumentRoot => root, :BindAddress => "127.0.0.1"})```
-
-  This will prevent webbrick from accepting connections from remote hosts (a portscan with nmap 
-  suggests this is true), and exposing your file system to the internet. I also suggest running 
-  this with a local firewall to prevent external connections.
-
-  Brian Emery, August 2021
-
-* Fixed a trailing slash bug when serving a single TW file directly, expanded on the instructions, and added an example NGINX proxy configuration and a systemd service.
-  
-  Stanimir Djevelekov, December 2021
+## Contributors
+### [Jim Foltz](https://gist.github.com/jimfoltz)
+- Original author
+### [Brian Emery](https://github.com/brianemery)
+- Added a bind address in the server definition - this will prevent the WEBrick server from accepting connections from remote hosts, and exposing your file system to the internet.
+### [Prehistoric Dog](https://github.com/korikori)
+- Fixed a trailing slash bug when serving a single TW file directly instead of a directory.
+- Expanded and reformatted the instructions, adding example code for a systemd service and an example NGINX reverse proxy configuration.

--- a/README.md
+++ b/README.md
@@ -15,8 +15,27 @@ If you want to host multiple TiddlyWikis, you can serve the whole subfolder, and
 
 `ruby tw5-server.rb folder`
 
-## Securing your site
-Suggest running this with a local firewall and/or proxy to secure external connections. The following is a working proxy configuration for NGINX with optional password protection:
+### Example systemd service
+
+You can automate your TiddlyWiki server with a systemd service:
+
+```
+[Unit]
+Description=TiddlyWiki
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/$USER/twiki
+ExecStart=/usr/bin/ruby tw5-server.rb folder/empty.html
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+```
+
+## Serving and securing your site
+We suggest running this with a local firewall and/or proxy to secure external connections. The following is a working proxy configuration for NGINX with optional password protection:
 
 ```nginx
 upstream tiddlywiki.example.com {
@@ -52,6 +71,6 @@ server {
 
   Brian Emery, August 2021
 
-* Fixed a trailing slash bug when serving a single TW file directly, expanded on the instructions, and added an example NGINX proxy configuration block.
+* Fixed a trailing slash bug when serving a single TW file directly, expanded on the instructions, and added an example NGINX proxy configuration and a systemd service.
   
   Stanimir Djevelekov, December 2021

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
-## TW5 SERVER
-Originally from:
-https://gist.github.com/jimfoltz/ee791c1bdd30ce137bc23cce826096da
+# TW5 SERVER
+Originally from https://gist.github.com/jimfoltz/ee791c1bdd30ce137bc23cce826096da by Jim Foltz.
 
 Allows editing and saving of [TiddlyWiki](https://tiddlywiki.com) in a browser.
 
-### USAGE
-Download TiddlyWiki from https://tiddlywiki.com/empty.html and
-save it in a subfolder of this script but NOT as index.html.
+## Installing / Getting started
+Download TiddlyWiki from https://tiddlywiki.com/empty.html and save it in a subfolder of this script but NOT as index.html.
 
 From the command line (e.g. Terminal on Mac):
 
@@ -18,7 +16,7 @@ If you want to host multiple TiddlyWikis, you can serve the whole subfolder, and
 
 `/usr/bin/ruby tw5-server.rb folder`
 
-### ALSO
+## Securing your site
 Suggest running this with a local firewall and/or proxy to prevent external connections. The following is a working (but unprotected) proxy configuration for NGINX:
 
 ```nginx
@@ -37,7 +35,7 @@ server {
 }
 ```
 
-### MODIFICATIONS
+## Modifications to the original script
 * Added a bind address in the server definition:
   ```server = WEBrick::HTTPServer.new({:Port => 8000, :DocumentRoot => root, :BindAddress => "127.0.0.1"})```
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,15 @@
 Allows editing and saving of [TiddlyWiki](https://tiddlywiki.com) in a browser. Originally from https://gist.github.com/jimfoltz/ee791c1bdd30ce137bc23cce826096da by Jim Foltz.
 
 ## Installing / Getting started
-Download TiddlyWiki from https://tiddlywiki.com/empty.html and save it in a subfolder of this script but NOT as index.html.
-
-From the command line (e.g. Terminal on Mac):
+First, download TiddlyWiki from https://tiddlywiki.com/empty.html and save it in a subfolder of this script but NOT as index.html. You can do this from the command line (e.g. Terminal on Mac) like so:
 
 `/usr/bin/wget https://tiddlywiki.com/empty.html -P folder/`
+
+If wget is unavailable, you can also use curl:
+
+`curl https://tiddlywiki.com/empty.html >> folder/empty.html`
+
+Then, to start the server, run the following:
 
 `/usr/bin/ruby tw5-server.rb folder/empty.html`
 
@@ -16,7 +20,7 @@ If you want to host multiple TiddlyWikis, you can serve the whole subfolder, and
 `/usr/bin/ruby tw5-server.rb folder`
 
 ## Securing your site
-Suggest running this with a local firewall and/or proxy to prevent external connections. The following is a working (but unprotected) proxy configuration for NGINX:
+Suggest running this with a local firewall and/or proxy to secure external connections. The following is a working (but unprotected) proxy configuration for NGINX:
 
 ```nginx
 upstream tiddlywiki.example.com {

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # TW5 SERVER
-Originally from https://gist.github.com/jimfoltz/ee791c1bdd30ce137bc23cce826096da by Jim Foltz.
 
-Allows editing and saving of [TiddlyWiki](https://tiddlywiki.com) in a browser.
+Allows editing and saving of [TiddlyWiki](https://tiddlywiki.com) in a browser. Originally from https://gist.github.com/jimfoltz/ee791c1bdd30ce137bc23cce826096da by Jim Foltz.
 
 ## Installing / Getting started
 Download TiddlyWiki from https://tiddlywiki.com/empty.html and save it in a subfolder of this script but NOT as index.html.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you want to host multiple TiddlyWikis, you can serve the whole subfolder, and
 
 ### Example systemd service
 
-You can automate your TiddlyWiki server with a systemd service:
+On Linux, you can automate your TiddlyWiki server with a systemd service:
 
 ```
 [Unit]

--- a/README.md
+++ b/README.md
@@ -5,19 +5,15 @@ Allows editing and saving of [TiddlyWiki](https://tiddlywiki.com) in a browser. 
 ## Installing / Getting started
 First, download TiddlyWiki from https://tiddlywiki.com/empty.html and save it in a subfolder of this script but NOT as index.html. You can do this from the command line (e.g. Terminal on Mac) like so:
 
-`/usr/bin/wget https://tiddlywiki.com/empty.html -P folder/`
-
-If wget is unavailable, you can also use curl:
-
 `curl https://tiddlywiki.com/empty.html >> folder/empty.html`
 
 Then, to start the server, run the following:
 
-`/usr/bin/ruby tw5-server.rb folder/empty.html`
+`ruby tw5-server.rb folder/empty.html`
 
 If you want to host multiple TiddlyWikis, you can serve the whole subfolder, and then pick the desired file from a folder listing that will be automatically generated:
 
-`/usr/bin/ruby tw5-server.rb folder`
+`ruby tw5-server.rb folder`
 
 ## Securing your site
 Suggest running this with a local firewall and/or proxy to secure external connections. The following is a working proxy configuration for NGINX with optional password protection:

--- a/README.md
+++ b/README.md
@@ -2,18 +2,51 @@
 Originally from:
 https://gist.github.com/jimfoltz/ee791c1bdd30ce137bc23cce826096da
 
-Allows editing and saving of tiddlywiki (https://tiddlywiki.com) in a browser.
+Allows editing and saving of [TiddlyWiki](https://tiddlywiki.com) in a browser.
 
-USAGE
+### USAGE
+Download TiddlyWiki from https://tiddlywiki.com/empty.html and
+save it in a subfolder of this script but NOT as index.html.
+
 From the command line (e.g. Terminal on Mac):
-/usr/bin/ruby tw5-server.rb /folder
 
-MODIFICATIONS
-Added a bind address in the server definition:
-server = WEBrick::HTTPServer.new({:Port => 8000, :DocumentRoot => root, :BindAddress => "127.0.0.1"})
+`/usr/bin/wget https://tiddlywiki.com/empty.html -P folder/`
 
-This will prevent webbrick from accepting connections from remote hosts (a portscan with nmap 
-suggests this is true), and exposing your file system to the internet. I also suggest running 
-this with a local firewall to prevent external connections.
+`/usr/bin/ruby tw5-server.rb folder/empty.html`
 
-Brian Emery, August 2021
+If you want to host multiple TiddlyWikis, you can serve the whole subfolder, and then pick the desired file from a folder listing that will be automatically generated:
+
+`/usr/bin/ruby tw5-server.rb folder`
+
+### ALSO
+Suggest running this with a local firewall and/or proxy to prevent external connections. The following is a working (but unprotected) proxy configuration for NGINX:
+
+```nginx
+upstream tiddlywiki.example.com {
+        server 127.0.0.1:8000;
+}
+
+server {
+        server_name tiddlywiki.example.com;
+        client_max_body_size 20M;
+
+        location / {
+                proxy_pass http://127.0.0.1:8000;
+                proxy_set_header Host $host;
+        }
+}
+```
+
+### MODIFICATIONS
+* Added a bind address in the server definition:
+  ```server = WEBrick::HTTPServer.new({:Port => 8000, :DocumentRoot => root, :BindAddress => "127.0.0.1"})```
+
+  This will prevent webbrick from accepting connections from remote hosts (a portscan with nmap 
+  suggests this is true), and exposing your file system to the internet. I also suggest running 
+  this with a local firewall to prevent external connections.
+
+  Brian Emery, August 2021
+
+* Fixed a trailing slash bug when serving a single TW file directly, expanded on the instructions, and added an example NGINX proxy configuration block.
+  
+  Stanimir Djevelekov, December 2021

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ After=network.target
 Type=simple
 WorkingDirectory=/home/$USER/twiki
 ExecStart=/usr/bin/ruby tw5-server.rb folder/empty.html
-Restart=on-failure
+Restart=always
 
 [Install]
 WantedBy=multi-user.target

--- a/tw5-server.rb
+++ b/tw5-server.rb
@@ -1,10 +1,14 @@
 # TW5 SERVER
 #
-# Allows editing and saving of tiddlywiki in a browser
+# Allows editing and saving of TiddlyWiki in a browser
 #
 # USAGE
+# Download TiddlyWiki from https://tiddlywiki.com/empty.html and
+# save it in its own subfolder as an .html file but NOT index.html.
+#
 # From the command line (e.g. Terminal on Mac):
-# /usr/bin/ruby tw5-server.rb /folder
+# /usr/bin/wget https://tiddlywiki.com/empty.html -P folder/
+# /usr/bin/ruby tw5-server.rb /folder/empty.html
 #
 # ALSO
 # suggest running this with a local firewall to prevent external connections.
@@ -31,7 +35,7 @@ module WEBrick
 
       class DefaultFileHandler
          def do_PUT(req, res)
-            file = "#{@config[:DocumentRoot]}#{req.path}"
+            file = "#{@config[:DocumentRoot]}#{req.path}".sub(/[\/]$/,'')
             res.body = ''
             unless Dir.exists? BACKUP_DIR
                Dir.mkdir BACKUP_DIR

--- a/tw5-server.rb
+++ b/tw5-server.rb
@@ -1,5 +1,4 @@
 # TW5 SERVER
-#
 # Allows editing and saving of TiddlyWiki in a browser.
 #
 # USAGE
@@ -8,13 +7,11 @@
 #
 # From the command line (e.g. Terminal on Mac):
 # /usr/bin/wget https://tiddlywiki.com/empty.html -P folder/
-# /usr/bin/ruby tw5-server.rb /folder/empty.html
-#
-# ALSO
-# Suggest running this with a local firewall and/or proxy to prevent external connections.
+# /usr/bin/ruby tw5-server.rb folder/empty.html
 #
 # Originally from:
 # https://gist.github.com/jimfoltz/ee791c1bdd30ce137bc23cce826096da
+# https://github.com/brianemery/tw5_server
 
 require 'webrick'
 require 'fileutils'

--- a/tw5-server.rb
+++ b/tw5-server.rb
@@ -1,6 +1,6 @@
 # TW5 SERVER
 #
-# Allows editing and saving of TiddlyWiki in a browser
+# Allows editing and saving of TiddlyWiki in a browser.
 #
 # USAGE
 # Download TiddlyWiki from https://tiddlywiki.com/empty.html and
@@ -11,7 +11,7 @@
 # /usr/bin/ruby tw5-server.rb /folder/empty.html
 #
 # ALSO
-# suggest running this with a local firewall to prevent external connections.
+# Suggest running this with a local firewall and/or proxy to prevent external connections.
 #
 # Originally from:
 # https://gist.github.com/jimfoltz/ee791c1bdd30ce137bc23cce826096da


### PR DESCRIPTION
Hi Brian, I wanted to use this to serve a TW site by directly pointing to the HTML file (in order to avoid the "view the folder listing, and click on your wiki html file" step), like so:

```ruby tw5-server.rb test/test.html```

However, this caused a bug where a trailing slash is always added to the filename, and Ruby thinks its a directory - so changes to TW can't be saved:

```[2021-12-18 15:44:10] ERROR Errno::ENOTDIR: Not a directory @ rb_sysopen - test/test.html/```

As a Ruby rookie, I wanted to see if removing the eventual trailing slash would be as simple as I thought, and it works as expected in my tests. It still doesn't work for me when the file is saved as index.html, but I got a working workaround so I haven't dug further.

I then went into the rabbit hole of revising and adding to your usage notes, applying Markdown to the README.md file, and adding an example NGINX proxy block.

Hope you find this useful.
Stanimir
